### PR TITLE
fix crash with ASJCore

### DIFF
--- a/src/main/java/com/ventooth/beddium/config/TerrainRenderingConfig.java
+++ b/src/main/java/com/ventooth/beddium/config/TerrainRenderingConfig.java
@@ -118,7 +118,9 @@ public final class TerrainRenderingConfig {
     @Config.DefaultStringList({
             "net.minecraft.*",
             "net.minecraftforge.*",
-            "cpw.mods.fml.*"
+            "cpw.mods.fml.*",
+            "org.lwjgl.*",
+            "org.lwjglx.*"
     })
     public static String[] FastFogAsmExclusions;
 


### PR DESCRIPTION
ASJCore allows to transform 
"org.lwjgl." and "org.lwjglx." , so Beddium transforms glDisable to call glDisable -> StackOverflowError
```
java.lang.StackOverflowError: Initializing game
	at Launch//org.lwjgl.opengl.GL11.glDisable(GL11.java:662)
	at Launch//com.ventooth.beddium.modules.TerrainRendering.fog.FogAsmHooks.beddium$glDisable(FogAsmHooks.java:73)
	at Launch//org.lwjgl.opengl.GL11.glDisable(GL11.java:662)
	at Launch//com.ventooth.beddium.modules.TerrainRendering.fog.FogAsmHooks.beddium$glDisable(FogAsmHooks.java:73)
	at Launch//org.lwjgl.opengl.GL11.glDisable(GL11.java:662)
	at Launch//com.ventooth.beddium.modules.TerrainRendering.fog.FogAsmHooks.beddium$glDisable(FogAsmHooks.java:73)
	at Launch//org.lwjgl.opengl.GL11.glDisable(GL11.java:662)
```
SAME COMMIT NEEDED TO master-java8 BRANCH!
(I hope I understand your configs way of working properly...)